### PR TITLE
Fix NovaRoute module path mismatch after org transfer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/azrtydxb/novanet
 go 1.26.0
 
 require (
-	github.com/containernetworking/cni v1.3.0
 	github.com/azrtydxb/NovaRoute v0.5.2
+	github.com/containernetworking/cni v1.3.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/spf13/cobra v1.10.2
@@ -75,3 +75,9 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+// NovaRoute was transferred from piwi3910 to azrtydxb org but its go.mod
+// still declares github.com/piwi3910/NovaRoute. This replace maps the old
+// module path so the build works until NovaRoute publishes a new release
+// with the updated module path.
+replace github.com/azrtydxb/NovaRoute v0.5.2 => github.com/piwi3910/NovaRoute v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
-github.com/azrtydxb/NovaRoute v0.5.2 h1:4PwGBZTGosC6G0l1qad5Z7oqcSqxD55yKuXe2FhA0pc=
-github.com/azrtydxb/NovaRoute v0.5.2/go.mod h1:JuhDydtChMsFyl8YfJyJBP4m0vPWgn/OnyBYfNWMDKI=
+github.com/piwi3910/NovaRoute v0.5.2 h1:4PwGBZTGosC6G0l1qad5Z7oqcSqxD55yKuXe2FhA0pc=
+github.com/piwi3910/NovaRoute v0.5.2/go.mod h1:JuhDydtChMsFyl8YfJyJBP4m0vPWgn/OnyBYfNWMDKI=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Summary

- Adds `replace` directive in `go.mod` to fix build failure caused by NovaRoute's `go.mod` still declaring `github.com/piwi3910/NovaRoute` after the repo was transferred to `azrtydxb` org
- `go build ./...` now succeeds (previously failed with checksum mismatch)

## Test plan

- [x] `go build ./...` compiles cleanly (all packages including `cmd/novanet-agent`)
- [x] `go test ./internal/ipam/...` passes