### PR TITLE
Upgrade Go to 1.26.1

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -6,7 +6,7 @@
 #   2. Runtime stage uses the target platform's Alpine.
 
 # ---------- builder (always runs on native build platform) ----------
-FROM --platform=$BUILDPLATFORM golang:1.26.0-bookworm AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.1-bookworm AS builder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.1-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/azrtydxb/novanet
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/azrtydxb/NovaRoute v0.5.2


### PR DESCRIPTION
## Summary
- Upgrade Go from 1.26.0 to 1.26.1 in go.mod and all Dockerfiles
- Fixes Go stdlib vulnerabilities (crypto/x509, net/http, net/url)

## Test plan
- [ ] CI passes with Go 1.26.1
- [ ] All builds succeed with updated Dockerfiles