### PR TITLE
fix: increase dataplane memory limit for eBPF maps

### DIFF
--- a/deploy/helm/novanet/values.yaml
+++ b/deploy/helm/novanet/values.yaml
@@ -90,10 +90,10 @@ resources:
   dataplane:
     requests:
       cpu: 100m
-      memory: 64Mi
+      memory: 128Mi
     limits:
       cpu: 500m
-      memory: 128Mi
+      memory: 512Mi
   frr:
     requests:
       cpu: 50m


### PR DESCRIPTION
## Summary
- Increase dataplane container memory limit from 128Mi to 512Mi
- Increase memory request from 64Mi to 128Mi
- Required because v1.14.2 eBPF maps (SOCK_HASH, RL_TOKENS, BACKEND_HEALTH) exceed 128Mi under kernel 6.12+ cgroup memory accounting

## Test plan
- [ ] Deploy via ArgoCD, verify dataplane pods start without ENOMEM
- [ ] Verify eBPF maps load successfully on all nodes