### PR TITLE
Fix AddPod panic on short ContainerId and add field validation

### DIFF
--- a/cmd/novanet-agent/main.go
+++ b/cmd/novanet-agent/main.go
@@ -236,6 +236,26 @@ func (s *agentServer) AddPod(ctx context.Context, req *pb.AddPodRequest) (*pb.Ad
 		metricCNIAddLatency.Observe(time.Since(start).Seconds())
 	}()
 
+	// Validate required fields.
+	if req.PodName == "" {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "PodName is required")
+	}
+	if req.PodNamespace == "" {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "PodNamespace is required")
+	}
+	if req.ContainerId == "" {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "ContainerId is required")
+	}
+	if req.Netns == "" {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "Netns is required")
+	}
+	if req.IfName == "" {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "IfName is required")
+	}
+	if len(req.ContainerId) < 11 {
+		return nil, grpcstatus.Errorf(codes.InvalidArgument, "ContainerId too short: must be at least 11 characters, got %d", len(req.ContainerId))
+	}
+
 	key := req.PodNamespace + "/" + req.PodName
 	s.logger.Info("AddPod request",
 		zap.String("pod", key),


### PR DESCRIPTION
## Summary
- Add validation for required fields (PodName, PodNamespace, ContainerId, Netns, IfName) in `AddPod` gRPC handler, returning `codes.InvalidArgument` for missing values
- Add length check on ContainerId (must be >= 11 chars) to prevent panic when generating host veth name via `req.ContainerId[:11]`

Fixes #35, Fixes #47

## Test plan
- [ ] Verify `go vet` passes on `cmd/novanet-agent`
- [ ] Send AddPod request with empty PodName -> expect InvalidArgument
- [ ] Send AddPod request with ContainerId shorter than 11 chars -> expect InvalidArgument with descriptive message
- [ ] Send valid AddPod request -> expect normal behavior unchanged