### PR TITLE
fix: security hardening - pin CI actions, redact BGP passwords, bind metrics to localhost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
       helm: ${{ steps.filter.outputs.helm }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
           filters: |
@@ -59,11 +59,11 @@ jobs:
     if: needs.phase1-changes.outputs.go == 'true'
     runs-on: qnap-nas
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -77,7 +77,7 @@ jobs:
           fi
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           args: ${{ github.event_name == 'pull_request' && '--new-from-rev=origin/main' || '' }}
 
@@ -96,7 +96,7 @@ jobs:
     if: needs.phase1-changes.outputs.rust == 'true'
     runs-on: qnap-nas
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install system dependencies
         run: |
@@ -104,15 +104,15 @@ jobs:
           sudo apt-get install -y --no-install-recommends protobuf-compiler build-essential mold
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@0f1b44df7e9cbb178d781a242338dfa5e243ad7f # nightly
         with:
           components: rustfmt, clippy
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -137,10 +137,10 @@ jobs:
     if: needs.phase1-changes.outputs.helm == 'true'
     runs-on: qnap-nas
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Lint Helm chart
         run: helm lint deploy/helm/novanet/
@@ -174,10 +174,10 @@ jobs:
     if: ${{ !cancelled() && needs.phase1-gate.result == 'success' }}
     runs-on: qnap-nas
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.x'
 
@@ -193,7 +193,7 @@ jobs:
     if: ${{ !cancelled() && needs.phase1-gate.result == 'success' && github.event_name == 'pull_request' }}
     runs-on: qnap-nas
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -213,11 +213,11 @@ jobs:
     if: ${{ !cancelled() && needs.phase1-gate.result == 'success' }}
     runs-on: qnap-nas
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -229,7 +229,7 @@ jobs:
         run: govulncheck ./...
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         continue-on-error: true  # requires GITLEAKS_LICENSE for org repos
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -264,9 +264,9 @@ jobs:
     if: ${{ !cancelled() && needs.phase2-gate.result == 'success' }}
     runs-on: qnap-nas
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -297,7 +297,7 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@d61b558e8df85cb60d09ca3e5b09653b4477cea7 # v1
         with:
           name: "Go Test Results"
           path: test-results.xml
@@ -306,7 +306,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: go-coverage
           path: coverage.out
@@ -318,7 +318,7 @@ jobs:
     if: ${{ !cancelled() && needs.phase2-gate.result == 'success' && needs.phase1-changes.outputs.rust == 'true' }}
     runs-on: qnap-nas
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install system dependencies
         run: |
@@ -326,15 +326,15 @@ jobs:
           sudo apt-get install -y --no-install-recommends protobuf-compiler build-essential mold
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@0f1b44df7e9cbb178d781a242338dfa5e243ad7f # nightly
         with:
           components: rust-src, llvm-tools-preview
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -363,7 +363,7 @@ jobs:
 
       - name: Upload Rust test report
         if: always()
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@d61b558e8df85cb60d09ca3e5b09653b4477cea7 # v1
         with:
           name: "Rust Test Results"
           path: dataplane/target/nextest/ci/rust-test-results.xml
@@ -411,9 +411,9 @@ jobs:
           - binary: novanet-operator
             path: ./cmd/novanet-operator/
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -424,7 +424,7 @@ jobs:
           CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/${{ matrix.binary }} ${{ matrix.path }}
 
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.binary }}
           path: bin/${{ matrix.binary }}
@@ -436,7 +436,7 @@ jobs:
     if: ${{ !cancelled() && needs.phase3-gate.result == 'success' && needs.phase1-changes.outputs.rust == 'true' }}
     runs-on: qnap-nas
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build Rust/eBPF via Docker
         run: |
@@ -448,7 +448,7 @@ jobs:
           docker rm novanet-extract
 
       - name: Upload dataplane binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: novanet-dataplane
           path: bin/novanet-dataplane
@@ -460,10 +460,10 @@ jobs:
     if: ${{ !cancelled() && needs.phase3-gate.result == 'success' }}
     runs-on: qnap-nas
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build agent image (no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.agent
@@ -471,7 +471,7 @@ jobs:
           tags: novanet-agent:test
 
       - name: Build dataplane image (no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.dataplane
@@ -519,17 +519,17 @@ jobs:
           - image: novanet-dataplane
             dockerfile: Dockerfile.dataplane
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/ct.yml
+++ b/.github/workflows/ct.yml
@@ -31,8 +31,8 @@ jobs:
       github.event.inputs.test_suite == 'all' ||
       github.event.inputs.test_suite == 'functional'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -48,7 +48,7 @@ jobs:
             -- -race -tags=functional -count=1 ./...
       - name: Upload test report
         if: always()
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@d61b558e8df85cb60d09ca3e5b09653b4477cea7 # v1
         with:
           name: "CT: Functional Tests"
           path: ct-functional-results.xml
@@ -56,7 +56,7 @@ jobs:
           fail-on-error: false
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ct-functional-report
           path: ct-functional-results.xml
@@ -70,7 +70,7 @@ jobs:
       github.event.inputs.test_suite == 'all' ||
       github.event.inputs.test_suite == 'integration'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Run integration tests
         id: run-integration
         working-directory: tests/integration
@@ -103,7 +103,7 @@ jobs:
           XMLEOF
       - name: Upload test report
         if: always()
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@d61b558e8df85cb60d09ca3e5b09653b4477cea7 # v1
         with:
           name: "CT: Integration Tests"
           path: ct-integration-results.xml
@@ -111,7 +111,7 @@ jobs:
           fail-on-error: false
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ct-integration-report
           path: |
@@ -127,8 +127,8 @@ jobs:
       github.event.inputs.test_suite == 'all' ||
       github.event.inputs.test_suite == 'performance'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -144,7 +144,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: ct-performance-report
           path: benchmark-results.txt

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -15,7 +15,7 @@ jobs:
     name: Trivy Filesystem Scan
     runs-on: qnap-nas
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Trivy
         run: |
@@ -81,10 +81,10 @@ jobs:
           - image: novanet-dataplane
             dockerfile: Dockerfile.dataplane
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,13 +22,13 @@ jobs:
   build:
     runs-on: qnap-nas
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.x'
 
@@ -39,7 +39,7 @@ jobs:
         run: mkdocs build --strict
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: site
 
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,9 @@ jobs:
         goos: [linux]
         goarch: [amd64, arm64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
 
@@ -42,7 +42,7 @@ jobs:
             -C dist novanet-agent novanet-cni novanetctl
 
       - name: Upload release archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: novanet-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist/novanet-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
@@ -59,13 +59,13 @@ jobs:
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.arch.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -73,7 +73,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/azrtydxb/novanet/novanet-agent
           tags: |
@@ -83,7 +83,7 @@ jobs:
             type=raw,value=latest-${{ matrix.arch.name }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.agent
@@ -106,13 +106,13 @@ jobs:
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.arch.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -120,7 +120,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/azrtydxb/novanet/novanet-dataplane
           tags: |
@@ -130,7 +130,7 @@ jobs:
             type=raw,value=latest-${{ matrix.arch.name }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.dataplane
@@ -148,7 +148,7 @@ jobs:
     needs: [docker-agent, docker-dataplane]
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -184,16 +184,16 @@ jobs:
     needs: [build-go-binaries, docker-agent, docker-dataplane, docker-manifest]
     runs-on: qnap-nas
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download Go binary artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
           pattern: novanet-linux-*
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           generate_release_notes: true
           files: |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,7 +137,7 @@ The Helm chart generates a ConfigMap that is mounted as `/etc/novanet/novanet.js
     "socket_path": "/run/novanet/ebpf-services.sock"
   },
   "log_level": "info",
-  "metrics_address": ":9103"
+  "metrics_address": "127.0.0.1:9103"
 }
 ```
 
@@ -159,7 +159,7 @@ The Helm chart generates a ConfigMap that is mounted as `/etc/novanet/novanet.js
 | `log_level` | string | One of `"debug"`, `"info"`, `"warn"`, `"error"`. |
 | `ebpf_services.enabled` | bool | Enable the eBPF Services gRPC API. |
 | `ebpf_services.socket_path` | string | Unix socket path for the EBPFServices gRPC server. |
-| `metrics_address` | string | Address for the Prometheus metrics HTTP endpoint. |
+| `metrics_address` | string | Address for the Prometheus metrics HTTP endpoint (default: `127.0.0.1:9103`, localhost only). |
 
 ### Validation Rules
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -280,7 +280,7 @@ func DefaultConfig() *Config {
 		DSR:             false,
 		XDPAcceleration: "disabled",
 		LogLevel:        "info",
-		MetricsAddress:  ":9103",
+		MetricsAddress:  "127.0.0.1:9103",
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,7 +22,7 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.NodeCIDRMaskSize != 24 {
 		t.Errorf("unexpected node_cidr_mask_size: %d", cfg.NodeCIDRMaskSize)
 	}
-	if cfg.MetricsAddress != ":9103" {
+	if cfg.MetricsAddress != "127.0.0.1:9103" {
 		t.Errorf("unexpected metrics_address: %s", cfg.MetricsAddress)
 	}
 	if !cfg.Egress.MasqueradeEnabled {

--- a/internal/operator/controller/novanetcluster_controller.go
+++ b/internal/operator/controller/novanetcluster_controller.go
@@ -324,7 +324,7 @@ func (r *NovaNetClusterReconciler) reconcileConfigMap(ctx context.Context, clust
 		Egress:          novanetEgressCfg{MasqueradeEnabled: true},
 		Policy:          novanetPolicyCfg{DefaultDeny: false},
 		LogLevel:        cluster.Spec.Agent.LogLevel,
-		MetricsAddress:  fmt.Sprintf(":%d", metricsPort),
+		MetricsAddress:  fmt.Sprintf("127.0.0.1:%d", metricsPort),
 	}
 
 	if cluster.Spec.NovaRouteIntegration != nil && cluster.Spec.NovaRouteIntegration.Enabled {

--- a/internal/routing/config/config.go
+++ b/internal/routing/config/config.go
@@ -142,11 +142,26 @@ type PeerConfig struct {
 	// EBGPMultihop is the eBGP multihop TTL (0 = disabled).
 	EBGPMultihop uint32 `json:"ebgp_multihop"`
 
-	// Password is the BGP session password.
+	// Password is the BGP session password (plaintext, prefer PasswordSecretRef).
 	Password string `json:"password"` //nolint:gosec // BGP session password, not a credential
+
+	// PasswordSecretRef references a Kubernetes Secret containing the BGP
+	// session password. When set, it takes precedence over the plaintext
+	// Password field. The secret must contain a key named "password".
+	PasswordSecretRef *SecretRef `json:"password_secret_ref,omitempty"`
 
 	// MaxPrefixes is the maximum prefix limit (0 = default 1000).
 	MaxPrefixes uint32 `json:"max_prefixes"`
+}
+
+// SecretRef references a Kubernetes Secret by name and namespace.
+type SecretRef struct {
+	// Name is the name of the Kubernetes Secret.
+	Name string `json:"name"`
+
+	// Namespace is the namespace of the Kubernetes Secret.
+	// If empty, the agent's own namespace is used.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 // OwnerConfig defines the authentication and prefix policy for a single owner.

--- a/internal/routing/frr/client.go
+++ b/internal/routing/frr/client.go
@@ -125,10 +125,21 @@ func (c *Client) runConfig(ctx context.Context, commands []string) error {
 	}
 
 	for _, cmd := range commands {
-		c.log.Debug("VTY command OK", zap.String("cmd", cmd))
+		c.log.Debug("VTY command OK", zap.String("cmd", sanitizeCommand(cmd)))
 	}
 
 	return nil
+}
+
+// sanitizeCommand redacts sensitive values (e.g. BGP passwords) from FRR
+// VTY commands before they are written to log output.
+func sanitizeCommand(cmd string) string {
+	// Matches "neighbor <addr> password <secret>" - redact the password value.
+	if strings.Contains(cmd, " password ") {
+		idx := strings.Index(cmd, " password ")
+		return cmd[:idx] + " password ***"
+	}
+	return cmd
 }
 
 // runShow executes a show command via vtysh and returns the output.


### PR DESCRIPTION
## Summary

- **Issue #50**: Pin all GitHub Actions to full SHA digests across all 5 workflow files (ci.yml, release.yml, nightly-security.yml, ct.yml, pages.yml) to prevent supply-chain attacks via mutable tags
- **Issue #48**: Add `sanitizeCommand()` to redact BGP passwords from FRR VTY debug log output; add `PasswordSecretRef` field to `PeerConfig` as a secure alternative to plaintext passwords
- **Issue #49**: Change default metrics bind address from `:9103` (all interfaces) to `127.0.0.1:9103` (localhost only) in agent config, operator controller, and documentation

Fixes #50, Fixes #48, Fixes #49

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./internal/config/ ./internal/routing/config/ ./internal/routing/frr/` passes
- [x] Pre-commit lint hooks pass (golangci-lint)
- [ ] Verify CI workflows still trigger correctly with SHA-pinned actions
- [ ] Verify metrics endpoint is only accessible from localhost
- [ ] Verify BGP password is masked as `***` in debug logs