### PR TITLE
fix: bound DNS cache with LRU eviction

### DIFF
--- a/internal/policy/dns_cache.go
+++ b/internal/policy/dns_cache.go
@@ -12,6 +12,9 @@ import (
 // defaultDNSTTL is the default time-to-live for cached DNS entries.
 const defaultDNSTTL = 5 * time.Minute
 
+// defaultMaxEntries is the default maximum number of entries in the DNS cache.
+const defaultMaxEntries = 10000
+
 // DNSResolver is the function signature for resolving hostnames to IPs.
 // It exists to allow injection of test doubles.
 type DNSResolver func(ctx context.Context, host string) ([]net.IP, error)
@@ -30,23 +33,35 @@ func defaultResolver(ctx context.Context, host string) ([]net.IP, error) {
 	return ips, nil
 }
 
-// DNSCache caches DNS resolution results for FQDN-based policy peers.
-// It stores resolved IPs and their TTLs, and supports periodic refresh.
-type DNSCache struct {
-	mu       sync.RWMutex
-	entries  map[string][]net.IP  // FQDN -> resolved IPs
-	ttls     map[string]time.Time // FQDN -> expiry
-	logger   *zap.Logger
-	resolver DNSResolver
+// dnsCacheEntry holds a cached DNS result along with LRU tracking metadata.
+type dnsCacheEntry struct {
+	ips        []net.IP
+	expiry     time.Time
+	lastAccess time.Time
 }
 
-// NewDNSCache creates a new DNS cache.
-func NewDNSCache(logger *zap.Logger) *DNSCache {
+// DNSCache caches DNS resolution results for FQDN-based policy peers.
+// It stores resolved IPs and their TTLs, supports periodic refresh, and
+// enforces a maximum size with LRU eviction.
+type DNSCache struct {
+	mu         sync.RWMutex
+	entries    map[string]*dnsCacheEntry
+	maxEntries int
+	logger     *zap.Logger
+	resolver   DNSResolver
+}
+
+// NewDNSCache creates a new DNS cache with the given maximum number of entries.
+// If maxEntries is <= 0, defaultMaxEntries (10000) is used.
+func NewDNSCache(logger *zap.Logger, maxEntries int) *DNSCache {
+	if maxEntries <= 0 {
+		maxEntries = defaultMaxEntries
+	}
 	return &DNSCache{
-		entries:  make(map[string][]net.IP),
-		ttls:     make(map[string]time.Time),
-		logger:   logger,
-		resolver: defaultResolver,
+		entries:    make(map[string]*dnsCacheEntry),
+		maxEntries: maxEntries,
+		logger:     logger,
+		resolver:   defaultResolver,
 	}
 }
 
@@ -58,16 +73,25 @@ func (c *DNSCache) SetResolver(resolver DNSResolver) {
 	c.resolver = resolver
 }
 
+// Size returns the current number of entries in the cache.
+func (c *DNSCache) Size() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}
+
 // Resolve returns the cached IPs for the given FQDN, performing a lookup
 // if the entry is missing or expired.
 func (c *DNSCache) Resolve(fqdn string) []net.IP {
 	c.mu.RLock()
-	ips, ok := c.entries[fqdn]
-	expiry, hasExpiry := c.ttls[fqdn]
+	entry, ok := c.entries[fqdn]
 	c.mu.RUnlock()
 
-	if ok && hasExpiry && time.Now().Before(expiry) {
-		return ips
+	if ok && time.Now().Before(entry.expiry) {
+		c.mu.Lock()
+		entry.lastAccess = time.Now()
+		c.mu.Unlock()
+		return entry.ips
 	}
 
 	// Cache miss or expired — resolve.
@@ -82,14 +106,20 @@ func (c *DNSCache) Resolve(fqdn string) []net.IP {
 		)
 		// Return stale data if available.
 		if ok {
-			return ips
+			return entry.ips
 		}
 		return nil
 	}
 
+	now := time.Now()
+
 	c.mu.Lock()
-	c.entries[fqdn] = resolved
-	c.ttls[fqdn] = time.Now().Add(defaultDNSTTL)
+	c.entries[fqdn] = &dnsCacheEntry{
+		ips:        resolved,
+		expiry:     now.Add(defaultDNSTTL),
+		lastAccess: now,
+	}
+	c.evictLocked()
 	c.mu.Unlock()
 
 	c.logger.Debug("resolved FQDN",
@@ -98,6 +128,30 @@ func (c *DNSCache) Resolve(fqdn string) []net.IP {
 	)
 
 	return resolved
+}
+
+// evictLocked removes the least recently used entry if the cache exceeds maxEntries.
+// Must be called with c.mu held for writing.
+func (c *DNSCache) evictLocked() {
+	for len(c.entries) > c.maxEntries {
+		var oldestKey string
+		var oldestTime time.Time
+		first := true
+
+		for key, entry := range c.entries {
+			if first || entry.lastAccess.Before(oldestTime) {
+				oldestKey = key
+				oldestTime = entry.lastAccess
+				first = false
+			}
+		}
+
+		c.logger.Debug("evicting DNS cache entry (LRU)",
+			zap.String("fqdn", oldestKey),
+			zap.Int("cache_size", len(c.entries)),
+		)
+		delete(c.entries, oldestKey)
+	}
 }
 
 // Refresh re-resolves all cached FQDNs and returns the number of entries
@@ -124,8 +178,13 @@ func (c *DNSCache) Refresh() int {
 			continue
 		}
 
+		now := time.Now()
 		c.mu.Lock()
-		old := c.entries[fqdn]
+		entry := c.entries[fqdn]
+		var old []net.IP
+		if entry != nil {
+			old = entry.ips
+		}
 		if !ipsEqual(old, resolved) {
 			changed++
 			c.logger.Info("DNS entry changed on refresh",
@@ -134,8 +193,11 @@ func (c *DNSCache) Refresh() int {
 				zap.Int("new_count", len(resolved)),
 			)
 		}
-		c.entries[fqdn] = resolved
-		c.ttls[fqdn] = time.Now().Add(defaultDNSTTL)
+		c.entries[fqdn] = &dnsCacheEntry{
+			ips:        resolved,
+			expiry:     now.Add(defaultDNSTTL),
+			lastAccess: now,
+		}
 		c.mu.Unlock()
 	}
 
@@ -148,9 +210,9 @@ func (c *DNSCache) GetAll() map[string][]net.IP {
 	defer c.mu.RUnlock()
 
 	result := make(map[string][]net.IP, len(c.entries))
-	for fqdn, ips := range c.entries {
-		ipsCopy := make([]net.IP, len(ips))
-		copy(ipsCopy, ips)
+	for fqdn, entry := range c.entries {
+		ipsCopy := make([]net.IP, len(entry.ips))
+		copy(ipsCopy, entry.ips)
 		result[fqdn] = ipsCopy
 	}
 	return result

--- a/internal/policy/dns_cache_test.go
+++ b/internal/policy/dns_cache_test.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"sync/atomic"
 	"testing"
@@ -12,7 +13,7 @@ import (
 
 func testDNSCache() *DNSCache {
 	logger, _ := zap.NewDevelopment()
-	return NewDNSCache(logger)
+	return NewDNSCache(logger, defaultMaxEntries)
 }
 
 func TestDNSCacheResolve(t *testing.T) {
@@ -27,7 +28,6 @@ func TestDNSCacheResolve(t *testing.T) {
 		return nil, &net.DNSError{Err: "not found", Name: host}
 	})
 
-	// First call should resolve.
 	ips := cache.Resolve("example.com")
 	if len(ips) != 1 {
 		t.Fatalf("expected 1 IP, got %d", len(ips))
@@ -39,7 +39,6 @@ func TestDNSCacheResolve(t *testing.T) {
 		t.Fatalf("expected 1 resolver call, got %d", callCount.Load())
 	}
 
-	// Second call should use cache (no additional resolver call).
 	ips = cache.Resolve("example.com")
 	if len(ips) != 1 {
 		t.Fatalf("expected 1 IP from cache, got %d", len(ips))
@@ -77,19 +76,16 @@ func TestDNSCacheRefresh(t *testing.T) {
 		return nil, &net.DNSError{Err: "not found", Name: host}
 	})
 
-	// Initial resolve.
 	ips := cache.Resolve("example.com")
 	if len(ips) != 1 || ips[0].String() != "1.1.1.1" {
 		t.Fatalf("expected 1.1.1.1, got %v", ips)
 	}
 
-	// Refresh should detect the change.
 	changed := cache.Refresh()
 	if changed != 1 {
 		t.Fatalf("expected 1 changed entry, got %d", changed)
 	}
 
-	// Verify the cache is updated.
 	all := cache.GetAll()
 	if len(all["example.com"]) != 1 || all["example.com"][0].String() != "2.2.2.2" {
 		t.Fatalf("expected 2.2.2.2 after refresh, got %v", all["example.com"])
@@ -165,7 +161,7 @@ func TestDNSCacheExpiredEntry(t *testing.T) {
 	cache := testDNSCache()
 
 	callCount := atomic.Int32{}
-	cache.SetResolver(func(_ context.Context, host string) ([]net.IP, error) {
+	cache.SetResolver(func(_ context.Context, _ string) ([]net.IP, error) {
 		c := callCount.Add(1)
 		if c == 1 {
 			return []net.IP{net.ParseIP("1.1.1.1")}, nil
@@ -173,20 +169,152 @@ func TestDNSCacheExpiredEntry(t *testing.T) {
 		return []net.IP{net.ParseIP("2.2.2.2")}, nil
 	})
 
-	// Initial resolve.
 	cache.Resolve("example.com")
 
-	// Manually expire the entry.
 	cache.mu.Lock()
-	cache.ttls["example.com"] = time.Now().Add(-1 * time.Second)
+	cache.entries["example.com"].expiry = time.Now().Add(-1 * time.Second)
 	cache.mu.Unlock()
 
-	// Should re-resolve since expired.
 	ips := cache.Resolve("example.com")
 	if len(ips) != 1 || ips[0].String() != "2.2.2.2" {
 		t.Fatalf("expected 2.2.2.2 after expiry, got %v", ips)
 	}
 	if callCount.Load() != 2 {
 		t.Fatalf("expected 2 resolver calls after expiry, got %d", callCount.Load())
+	}
+}
+
+func TestDNSCacheSize(t *testing.T) {
+	cache := testDNSCache()
+
+	cache.SetResolver(func(_ context.Context, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("1.1.1.1")}, nil
+	})
+
+	if cache.Size() != 0 {
+		t.Fatalf("expected size 0, got %d", cache.Size())
+	}
+
+	cache.Resolve("a.example.com")
+	if cache.Size() != 1 {
+		t.Fatalf("expected size 1, got %d", cache.Size())
+	}
+
+	cache.Resolve("b.example.com")
+	if cache.Size() != 2 {
+		t.Fatalf("expected size 2, got %d", cache.Size())
+	}
+
+	cache.Resolve("a.example.com")
+	if cache.Size() != 2 {
+		t.Fatalf("expected size 2 after re-resolve, got %d", cache.Size())
+	}
+}
+
+func TestDNSCacheLRUEviction(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	cache := NewDNSCache(logger, 3)
+
+	cache.SetResolver(func(_ context.Context, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("1.1.1.1")}, nil
+	})
+
+	cache.Resolve("a.example.com")
+	cache.Resolve("b.example.com")
+	cache.Resolve("c.example.com")
+
+	if cache.Size() != 3 {
+		t.Fatalf("expected size 3, got %d", cache.Size())
+	}
+
+	cache.Resolve("a.example.com")
+
+	cache.Resolve("d.example.com")
+
+	if cache.Size() != 3 {
+		t.Fatalf("expected size 3 after eviction, got %d", cache.Size())
+	}
+
+	all := cache.GetAll()
+
+	if _, ok := all["d.example.com"]; !ok {
+		t.Fatal("expected d.example.com to be present after insertion")
+	}
+
+	if _, ok := all["a.example.com"]; !ok {
+		t.Fatal("expected a.example.com to be present (recently accessed)")
+	}
+
+	if _, ok := all["b.example.com"]; ok {
+		t.Fatal("expected b.example.com to be evicted (it was LRU)")
+	}
+}
+
+func TestDNSCacheLRUEvictionOrder(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	cache := NewDNSCache(logger, 2)
+
+	cache.SetResolver(func(_ context.Context, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("10.0.0.1")}, nil
+	})
+
+	cache.Resolve("first.example.com")
+	cache.Resolve("second.example.com")
+
+	cache.Resolve("first.example.com")
+
+	cache.Resolve("third.example.com")
+
+	if cache.Size() != 2 {
+		t.Fatalf("expected size 2, got %d", cache.Size())
+	}
+
+	all := cache.GetAll()
+	if _, ok := all["first.example.com"]; !ok {
+		t.Fatal("expected first.example.com to survive (recently accessed)")
+	}
+	if _, ok := all["third.example.com"]; !ok {
+		t.Fatal("expected third.example.com to be present (just added)")
+	}
+	if _, ok := all["second.example.com"]; ok {
+		t.Fatal("expected second.example.com to be evicted")
+	}
+}
+
+func TestDNSCacheMaxEntriesDefault(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+
+	cache := NewDNSCache(logger, 0)
+	if cache.maxEntries != defaultMaxEntries {
+		t.Fatalf("expected default max entries %d, got %d", defaultMaxEntries, cache.maxEntries)
+	}
+
+	cache = NewDNSCache(logger, -1)
+	if cache.maxEntries != defaultMaxEntries {
+		t.Fatalf("expected default max entries %d, got %d", defaultMaxEntries, cache.maxEntries)
+	}
+}
+
+func TestDNSCacheEvictionUnderLoad(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	maxSize := 100
+	cache := NewDNSCache(logger, maxSize)
+
+	cache.SetResolver(func(_ context.Context, _ string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("10.0.0.1")}, nil
+	})
+
+	for i := 0; i < maxSize+50; i++ {
+		cache.Resolve(fmt.Sprintf("host-%d.example.com", i))
+	}
+
+	if cache.Size() != maxSize {
+		t.Fatalf("expected cache size %d, got %d", maxSize, cache.Size())
+	}
+
+	all := cache.GetAll()
+	lastKey := fmt.Sprintf("host-%d.example.com", maxSize+49)
+	if _, ok := all[lastKey]; !ok {
+		t.Fatalf("expected most recent entry %s to be present", lastKey)
 	}
 }

--- a/internal/policy/extended.go
+++ b/internal/policy/extended.go
@@ -39,7 +39,7 @@ func NewExtendedCompiler(identityAllocator *identity.Allocator, logger *zap.Logg
 			identityAllocator: identityAllocator,
 			logger:            logger,
 		},
-		dnsCache: NewDNSCache(logger),
+		dnsCache: NewDNSCache(logger, defaultMaxEntries),
 	}
 }
 

--- a/internal/policy/extended_test.go
+++ b/internal/policy/extended_test.go
@@ -19,7 +19,7 @@ func testExtendedCompiler() *ExtendedCompiler {
 }
 
 func mockDNSCache(logger *zap.Logger) *DNSCache {
-	cache := NewDNSCache(logger)
+	cache := NewDNSCache(logger, defaultMaxEntries)
 	cache.SetResolver(func(_ context.Context, host string) ([]net.IP, error) {
 		switch host {
 		case "api.example.com":


### PR DESCRIPTION
## Summary
- Add `maxEntries` field to `DNSCache` (default 10,000) with LRU eviction when the cache is full
- Track `lastAccess` time per entry; on cache hit, update access time; on insert beyond capacity, evict the least recently used entry
- Add `Size() int` method for observability
- Update `NewDNSCache` constructor to accept `maxEntries` parameter; update all callers
- Add 5 new tests covering: `Size()`, LRU eviction, eviction order, default max entries, and eviction under load (150 entries into a size-100 cache)

## Test plan
- [x] All existing DNS cache tests pass (no regressions)
- [x] `TestDNSCacheSize` - verifies Size() returns correct count
- [x] `TestDNSCacheLRUEviction` - verifies LRU entry is evicted when cache is full
- [x] `TestDNSCacheLRUEvictionOrder` - verifies recently accessed entries survive eviction
- [x] `TestDNSCacheMaxEntriesDefault` - verifies 0 and negative values use default (10000)
- [x] `TestDNSCacheEvictionUnderLoad` - verifies cache stays bounded under bulk inserts
- [x] `go test ./internal/policy/...` passes
- [x] `golangci-lint` passes

Fixes #38