### PR TITLE
Replace privileged:true with explicit capabilities

### DIFF
--- a/deploy/helm/novanet/templates/daemonset.yaml
+++ b/deploy/helm/novanet/templates/daemonset.yaml
@@ -111,7 +111,17 @@ spec:
           resources:
             {{- toYaml .Values.resources.agent | nindent 12 }}
           securityContext:
-            privileged: true
+            privileged: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              add:
+                - NET_ADMIN
+                - SYS_ADMIN
+                - BPF
+                - NET_RAW
+                - SYS_RESOURCE
+              drop:
+                - ALL
           volumeMounts:
             - name: config
               mountPath: /etc/novanet
@@ -164,7 +174,18 @@ spec:
           resources:
             {{- toYaml .Values.resources.dataplane | nindent 12 }}
           securityContext:
-            privileged: true
+            privileged: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              add:
+                - NET_ADMIN
+                - SYS_ADMIN
+                - BPF
+                - NET_RAW
+                - SYS_RESOURCE
+                - PERFMON
+              drop:
+                - ALL
           volumeMounts:
             - name: run-novanet
               mountPath: /run/novanet
@@ -180,7 +201,14 @@ spec:
           image: "{{ .Values.image.frr.repository }}:{{ .Values.image.frr.tag }}"
           imagePullPolicy: {{ .Values.image.frr.pullPolicy }}
           securityContext:
-            privileged: true
+            privileged: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_RAW
+              drop:
+                - ALL
           volumeMounts:
             - name: frr-run
               mountPath: /run/frr


### PR DESCRIPTION
## Summary
- Replace blanket `privileged: true` with explicit Linux capability lists for all three containers in the DaemonSet (agent, dataplane, FRR)
- Add `readOnlyRootFilesystem: true` to all three containers
- Init container left unchanged (already uses `privileged: false` with `drop: ALL`)

### Capability assignments
| Container | Capabilities |
|-----------|-------------|
| Agent | NET_ADMIN, SYS_ADMIN, BPF, NET_RAW, SYS_RESOURCE |
| Dataplane | NET_ADMIN, SYS_ADMIN, BPF, NET_RAW, SYS_RESOURCE, PERFMON |
| FRR | NET_ADMIN, NET_RAW |

Fixes #37

## Test plan
- [ ] Deploy with `helm upgrade` and verify all pods start successfully
- [ ] Confirm CNI ADD/DEL operations work (pod creation/deletion)
- [ ] Verify eBPF map creation and TC program attachment succeed
- [ ] In native routing mode, verify FRR container starts and establishes BGP sessions