### PR TITLE
fix: add missing EbpfContext import for sk_lookup_mesh

### DIFF
--- a/dataplane/novanet-ebpf/src/main.rs
+++ b/dataplane/novanet-ebpf/src/main.rs
@@ -27,6 +27,7 @@ use aya_ebpf::{
     macros::{cgroup_sock_addr, classifier, map, sk_lookup, sk_msg, sock_ops},
     maps::{Array, HashMap, LruHashMap, PerCpuArray, PerCpuHashMap, RingBuf, SockHash},
     programs::{SkLookupContext, SkMsgContext, SockAddrContext, SockOpsContext, TcContext},
+    EbpfContext,
 };
 use network_types::{
     eth::{EthHdr, EtherType},


### PR DESCRIPTION
## Summary
- Add `EbpfContext` trait import to fix `as_ptr()` method resolution on `SkLookupContext`
- The sk_lookup_mesh program uses `ctx.as_ptr()` which requires the `EbpfContext` trait to be in scope
- This fixes the Docker dataplane arm64 build failure in the v1.14.3 release pipeline

## Test plan
- [ ] Docker dataplane builds succeed for both amd64 and arm64
- [ ] CI passes